### PR TITLE
Add Thunderbird mail translation MVP

### DIFF
--- a/thunderbird/README.md
+++ b/thunderbird/README.md
@@ -18,6 +18,7 @@ The extension requests the following permissions:
 - `storage` – save engine and target language settings.
 - `menus` – reserved for future context menu integration.
 - `messagesRead` – access the displayed message contents.
+- `*://translate.googleapis.com/*` and `*://api.cognitive.microsofttranslator.com/*` – call the translation services.
 
 ## Engine setup
 

--- a/thunderbird/README.md
+++ b/thunderbird/README.md
@@ -19,7 +19,6 @@ The extension requests the following permissions:
 - `menus` – reserved for future context menu integration.
 - `messagesRead` – access the displayed message contents.
 - `tabs` – communicate with the content script.
-- Host permissions to call Google or Microsoft translation APIs.
 
 ## Engine setup
 

--- a/thunderbird/README.md
+++ b/thunderbird/README.md
@@ -18,7 +18,6 @@ The extension requests the following permissions:
 - `storage` – save engine and target language settings.
 - `menus` – reserved for future context menu integration.
 - `messagesRead` – access the displayed message contents.
-- `tabs` – communicate with the content script.
 
 ## Engine setup
 

--- a/thunderbird/README.md
+++ b/thunderbird/README.md
@@ -1,0 +1,38 @@
+# TWP for Thunderbird (MVP)
+
+Minimal Thunderbird MailExtension that translates the currently displayed email using Google or Microsoft.
+
+## Install
+
+1. Build the extension into an `.xpi` archive (zip).
+   ```
+   cd thunderbird
+   zip -r ../twp-tb-mvp.xpi *
+   ```
+2. In Thunderbird open Add-ons Manager → Gear → Install Add-on From File… and select the generated `.xpi`.
+
+## Permissions
+
+The extension requests the following permissions:
+
+- `storage` – save engine and target language settings.
+- `menus` – reserved for future context menu integration.
+- `messagesRead` – access the displayed message contents.
+- `tabs` – communicate with the content script.
+- Host permissions to call Google or Microsoft translation APIs.
+
+## Engine setup
+
+Google Translate works out of the box.
+
+Microsoft Translator requires an API key stored under `msKey` in the extension’s local storage. You can set it from the developer console:
+
+```js
+browser.storage.local.set({msKey: 'YOUR_KEY'});
+```
+
+## Known limitations
+
+- Only manual translation is supported.
+- Translates entire message body; quoted replies (`blockquote[type="cite"]`) are skipped.
+- No automatic language detection or automatic translation.

--- a/thunderbird/background.js
+++ b/thunderbird/background.js
@@ -3,12 +3,28 @@ const DEFAULTS = {
   target: 'es'
 };
 
+let contentPort = null;
+let pendingStatusResolve = null;
+
 async function getSettings() {
   const stored = await browser.storage.local.get(DEFAULTS);
   return Object.assign({}, DEFAULTS, stored);
 }
 
 browser.runtime.onMessage.addListener(async (msg) => {
+  if (msg.type === 'TOGGLE') {
+    contentPort?.postMessage({ type: 'TOGGLE', engine: msg.engine, to: msg.to });
+    return true;
+  }
+  if (msg.type === 'STATUS') {
+    if (!contentPort) {
+      return false;
+    }
+    return await new Promise(resolve => {
+      pendingStatusResolve = resolve;
+      contentPort.postMessage({ type: 'STATUS_REQUEST' });
+    });
+  }
   if (msg.type === 'GET_SETTINGS') {
     return await getSettings();
   }
@@ -18,6 +34,19 @@ browser.runtime.onMessage.addListener(async (msg) => {
   }
   if (msg.type === 'TRANSLATE_CHUNK') {
     return await translateTexts(msg.texts, msg.engine, msg.from || null, msg.to);
+  }
+});
+
+browser.runtime.onConnect.addListener(port => {
+  if (port.name === 'content') {
+    contentPort = port;
+    port.onDisconnect.addListener(() => { contentPort = null; });
+    port.onMessage.addListener(msg => {
+      if (msg.type === 'STATUS_RESPONSE' && pendingStatusResolve) {
+        pendingStatusResolve(msg.translated);
+        pendingStatusResolve = null;
+      }
+    });
   }
 });
 

--- a/thunderbird/background.js
+++ b/thunderbird/background.js
@@ -1,0 +1,60 @@
+const DEFAULTS = {
+  engine: 'google',
+  target: 'es'
+};
+
+async function getSettings() {
+  const stored = await browser.storage.local.get(DEFAULTS);
+  return Object.assign({}, DEFAULTS, stored);
+}
+
+browser.runtime.onMessage.addListener(async (msg) => {
+  if (msg.type === 'GET_SETTINGS') {
+    return await getSettings();
+  }
+  if (msg.type === 'SET_SETTINGS') {
+    await browser.storage.local.set(msg.settings);
+    return true;
+  }
+  if (msg.type === 'TRANSLATE_CHUNK') {
+    return await translateTexts(msg.texts, msg.engine, msg.from || null, msg.to);
+  }
+});
+
+async function translateTexts(texts, engine, from, to) {
+  try {
+    if (engine === 'microsoft') {
+      return await microsoftTranslate(texts, from, to);
+    }
+    return await googleTranslate(texts, from, to);
+  } catch (e) {
+    console.error('Translation error', e);
+    throw e;
+  }
+}
+
+async function googleTranslate(texts, from, to) {
+  const params = new URLSearchParams({ client: 'gtx', dt: 't', sl: from || 'auto', tl: to });
+  for (const t of texts) {
+    params.append('q', t);
+  }
+  const res = await fetch('https://translate.googleapis.com/translate_a/single?' + params.toString());
+  const json = await res.json();
+  return json[0].map(item => item[0]);
+}
+
+async function microsoftTranslate(texts, from, to) {
+  const url = 'https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&to=' + encodeURIComponent(to) + (from ? '&from=' + encodeURIComponent(from) : '');
+  const { msKey } = await browser.storage.local.get('msKey');
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Ocp-Apim-Subscription-Key': msKey || '',
+      'Ocp-Apim-Subscription-Region': 'global',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(texts.map(t => ({ Text: t })))
+  });
+  const json = await res.json();
+  return json.map(item => item.translations[0].text);
+}

--- a/thunderbird/content.css
+++ b/thunderbird/content.css
@@ -1,0 +1,1 @@
+/* placeholder for future styles */

--- a/thunderbird/content.js
+++ b/thunderbird/content.js
@@ -1,6 +1,7 @@
 let translated = false;
 let textNodes = [];
 let originalTexts = [];
+const port = browser.runtime.connect({ name: 'content' });
 
 function getTextNodes(root) {
   const nodes = [];
@@ -74,7 +75,7 @@ function restore() {
   translated = false;
 }
 
-browser.runtime.onMessage.addListener(async (msg) => {
+port.onMessage.addListener(async (msg) => {
   if (msg.type === 'TOGGLE') {
     if (translated) {
       restore();
@@ -86,7 +87,7 @@ browser.runtime.onMessage.addListener(async (msg) => {
         restore();
       }
     }
-  } else if (msg.type === 'STATUS') {
-    return translated;
+  } else if (msg.type === 'STATUS_REQUEST') {
+    port.postMessage({ type: 'STATUS_RESPONSE', translated });
   }
 });

--- a/thunderbird/content.js
+++ b/thunderbird/content.js
@@ -1,0 +1,92 @@
+let translated = false;
+let textNodes = [];
+let originalTexts = [];
+
+function getTextNodes(root) {
+  const nodes = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode: node => {
+      if (!node.textContent.trim()) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      const parent = node.parentElement;
+      if (!parent) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      if (['SCRIPT', 'STYLE'].includes(parent.tagName)) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      if (parent.closest('blockquote[type="cite"]')) {
+        return NodeFilter.FILTER_REJECT;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    }
+  });
+  while (walker.nextNode()) {
+    nodes.push(walker.currentNode);
+  }
+  return nodes;
+}
+
+function chunkTexts(texts, maxLen) {
+  const chunks = [];
+  let current = [];
+  let len = 0;
+  for (const t of texts) {
+    if (len + t.length > maxLen && current.length) {
+      chunks.push(current);
+      current = [];
+      len = 0;
+    }
+    current.push(t);
+    len += t.length;
+  }
+  if (current.length) {
+    chunks.push(current);
+  }
+  return chunks;
+}
+
+async function doTranslate(engine, to) {
+  textNodes = getTextNodes(document.body);
+  originalTexts = textNodes.map(n => n.textContent);
+  const chunks = chunkTexts(originalTexts, 4500);
+  let translatedTexts = [];
+  for (const chunk of chunks) {
+    const res = await browser.runtime.sendMessage({
+      type: 'TRANSLATE_CHUNK',
+      texts: chunk,
+      engine,
+      to
+    });
+    translatedTexts = translatedTexts.concat(res);
+  }
+  translatedTexts.forEach((text, i) => {
+    textNodes[i].textContent = text;
+  });
+  translated = true;
+}
+
+function restore() {
+  textNodes.forEach((n, i) => {
+    n.textContent = originalTexts[i];
+  });
+  translated = false;
+}
+
+browser.runtime.onMessage.addListener(async (msg) => {
+  if (msg.type === 'TOGGLE') {
+    if (translated) {
+      restore();
+    } else {
+      try {
+        await doTranslate(msg.engine, msg.to);
+      } catch (e) {
+        console.error('translate failed', e);
+        restore();
+      }
+    }
+  } else if (msg.type === 'STATUS') {
+    return translated;
+  }
+});

--- a/thunderbird/manifest.json
+++ b/thunderbird/manifest.json
@@ -2,12 +2,14 @@
   "manifest_version": 2,
   "name": "TWP for Thunderbird (MVP)",
   "version": "0.1.0",
-  "browser_specific_settings": { "gecko": { "id": "twp-tb-mvp@example.com", "strict_min_version": "115.0" } },
+  "applications": { "gecko": { "id": "twp-tb-mvp@example.com", "strict_min_version": "115.0" } },
   "description": "Translate the displayed email body in place using Google or Microsoft.",
   "permissions": [
     "storage",
     "menus",
-    "messagesRead"
+    "messagesRead",
+    "*://translate.googleapis.com/*",
+    "*://api.cognitive.microsofttranslator.com/*"
   ],
   "background": { "scripts": ["background.js"] },
   "message_display_action": { "default_title": "Translate", "default_popup": "popup.html" },

--- a/thunderbird/manifest.json
+++ b/thunderbird/manifest.json
@@ -1,0 +1,15 @@
+{
+  "manifest_version": 2,
+  "name": "TWP for Thunderbird (MVP)",
+  "version": "0.1.0",
+  "browser_specific_settings": { "gecko": { "id": "twp-tb-mvp@example.com", "strict_min_version": "115.0" } },
+  "description": "Translate the displayed email body in place using Google or Microsoft.",
+  "permissions": ["storage", "menus", "messagesRead", "tabs"],
+  "host_permissions": [
+    "*://translate.googleapis.com/*",
+    "*://api.cognitive.microsofttranslator.com/*"
+  ],
+  "background": { "scripts": ["background.js"] },
+  "message_display_action": { "default_title": "Translate", "default_popup": "popup.html" },
+  "message_display_scripts": [{ "js": ["content.js"], "css": ["content.css"] }]
+}

--- a/thunderbird/manifest.json
+++ b/thunderbird/manifest.json
@@ -4,8 +4,11 @@
   "version": "0.1.0",
   "browser_specific_settings": { "gecko": { "id": "twp-tb-mvp@example.com", "strict_min_version": "115.0" } },
   "description": "Translate the displayed email body in place using Google or Microsoft.",
-  "permissions": ["storage", "menus", "messagesRead", "tabs"],
-  "host_permissions": [
+  "permissions": [
+    "storage",
+    "menus",
+    "messagesRead",
+    "tabs",
     "*://translate.googleapis.com/*",
     "*://api.cognitive.microsofttranslator.com/*"
   ],

--- a/thunderbird/manifest.json
+++ b/thunderbird/manifest.json
@@ -7,8 +7,7 @@
   "permissions": [
     "storage",
     "menus",
-    "messagesRead",
-    "tabs"
+    "messagesRead"
   ],
   "background": { "scripts": ["background.js"] },
   "message_display_action": { "default_title": "Translate", "default_popup": "popup.html" },

--- a/thunderbird/manifest.json
+++ b/thunderbird/manifest.json
@@ -8,9 +8,7 @@
     "storage",
     "menus",
     "messagesRead",
-    "tabs",
-    "*://translate.googleapis.com/*",
-    "*://api.cognitive.microsofttranslator.com/*"
+    "tabs"
   ],
   "background": { "scripts": ["background.js"] },
   "message_display_action": { "default_title": "Translate", "default_popup": "popup.html" },

--- a/thunderbird/popup.html
+++ b/thunderbird/popup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+body { font-family: sans-serif; min-width: 200px; padding: 10px; }
+label { display: block; margin-bottom: 8px; }
+button { width: 100%; }
+</style>
+</head>
+<body>
+  <label>Engine:
+    <select id="engine">
+      <option value="google">Google</option>
+      <option value="microsoft">Microsoft</option>
+    </select>
+  </label>
+  <label>Target language:
+    <select id="target">
+      <option value="es">Spanish</option>
+      <option value="hy">Armenian</option>
+    </select>
+  </label>
+  <button id="action">Translate</button>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/thunderbird/popup.js
+++ b/thunderbird/popup.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', init);
+
+async function init() {
+  const engineSel = document.getElementById('engine');
+  const targetSel = document.getElementById('target');
+  const actionBtn = document.getElementById('action');
+
+  const settings = await browser.runtime.sendMessage({ type: 'GET_SETTINGS' });
+  engineSel.value = settings.engine;
+  targetSel.value = settings.target;
+
+  engineSel.addEventListener('change', async () => {
+    await browser.runtime.sendMessage({ type: 'SET_SETTINGS', settings: { engine: engineSel.value } });
+  });
+  targetSel.addEventListener('change', async () => {
+    await browser.runtime.sendMessage({ type: 'SET_SETTINGS', settings: { target: targetSel.value } });
+  });
+
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+  let translated = false;
+  try {
+    translated = await browser.tabs.sendMessage(tab.id, { type: 'STATUS' });
+  } catch (e) {
+    translated = false;
+  }
+  updateButton(translated);
+
+  actionBtn.addEventListener('click', async () => {
+    await browser.tabs.sendMessage(tab.id, { type: 'TOGGLE', engine: engineSel.value, to: targetSel.value });
+    translated = !translated;
+    updateButton(translated);
+  });
+}
+
+function updateButton(translated) {
+  const actionBtn = document.getElementById('action');
+  actionBtn.textContent = translated ? 'Restore' : 'Translate';
+}

--- a/thunderbird/popup.js
+++ b/thunderbird/popup.js
@@ -16,17 +16,16 @@ async function init() {
     await browser.runtime.sendMessage({ type: 'SET_SETTINGS', settings: { target: targetSel.value } });
   });
 
-  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
   let translated = false;
   try {
-    translated = await browser.tabs.sendMessage(tab.id, { type: 'STATUS' });
+    translated = await browser.runtime.sendMessage({ type: 'STATUS' });
   } catch (e) {
     translated = false;
   }
   updateButton(translated);
 
   actionBtn.addEventListener('click', async () => {
-    await browser.tabs.sendMessage(tab.id, { type: 'TOGGLE', engine: engineSel.value, to: targetSel.value });
+    await browser.runtime.sendMessage({ type: 'TOGGLE', engine: engineSel.value, to: targetSel.value });
     translated = !translated;
     updateButton(translated);
   });


### PR DESCRIPTION
## Summary
- add minimal Thunderbird MailExtension that translates message bodies via Google or Microsoft APIs
- include popup to select engine and target language and trigger translate/restore
- document installation, permissions, and engine setup
- drop bundled icon images to avoid binary assets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a632fdcc8883268eb3cfecbaf1737a