### PR TITLE
feat: add Thunderbird MailExtension skeleton

### DIFF
--- a/thunderbird/README.md
+++ b/thunderbird/README.md
@@ -1,0 +1,28 @@
+# TWP for Thunderbird
+
+Experimental Thunderbird MailExtension that translates email bodies in place using Google or Microsoft services. The extension injects a content script into message views and replaces text nodes with their translations. A toolbar button provides engine and language selection and allows restoring the original message.
+
+## Building
+
+The extension lives in the `thunderbird/` directory. To create an XPI file run:
+
+```
+zip -r twp-thunderbird.xpi *
+```
+
+## Installing
+
+1. Open Thunderbird and choose **Add-ons and Themes** from the application menu.
+2. Use the gear icon to select **Install Add-on From File…** and pick `twp-thunderbird.xpi`.
+3. Confirm the prompts and restart Thunderbird if requested.
+
+## Permissions
+
+- `messagesRead` / `messagesModify`: required to read and alter message bodies.
+- `storage`: stores preferences and API keys.
+- `menus`, `tabs`: UI integration.
+- host permissions for Google and Microsoft translation endpoints.
+
+## License
+
+This project is based on [TWP – Translate Web Pages](https://github.com/FilipePS/Traduzir-paginas-web) and is provided under the MPL-2.0 license.

--- a/thunderbird/_locales/en/messages.json
+++ b/thunderbird/_locales/en/messages.json
@@ -1,0 +1,6 @@
+{
+  "engine_label": { "message": "Engine" },
+  "language_label": { "message": "Target language" },
+  "translate_button": { "message": "Translate" },
+  "restore_button": { "message": "Show original" }
+}

--- a/thunderbird/background/engines/google.js
+++ b/thunderbird/background/engines/google.js
@@ -1,0 +1,21 @@
+// Google translation engine adapter
+// Derived from TWP project (MPL-2.0)
+
+export async function detect(text) {
+  const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=en&dt=t&q=${encodeURIComponent(text)}`;
+  const res = await fetch(url);
+  const data = await res.json();
+  return data[2];
+}
+
+export async function translateChunks(chunks, { from = 'auto', to }) {
+  const results = [];
+  for (const text of chunks) {
+    const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=${from}&tl=${to}&dt=t&q=${encodeURIComponent(text)}`;
+    const res = await fetch(url);
+    const data = await res.json();
+    const translated = data[0].map((seg) => seg[0]).join('');
+    results.push(translated);
+  }
+  return results;
+}

--- a/thunderbird/background/engines/index.js
+++ b/thunderbird/background/engines/index.js
@@ -1,0 +1,12 @@
+import * as google from "./google.js";
+import * as microsoft from "./microsoft.js";
+
+export function getEngine(name) {
+  switch (name) {
+    case "microsoft":
+      return microsoft;
+    case "google":
+    default:
+      return google;
+  }
+}

--- a/thunderbird/background/engines/microsoft.js
+++ b/thunderbird/background/engines/microsoft.js
@@ -1,0 +1,47 @@
+// Microsoft translation engine adapter
+// Requires an API key stored under `microsoftApiKey` in storage.local
+
+async function getKey() {
+  const { microsoftApiKey } = await browser.storage.local.get("microsoftApiKey");
+  return microsoftApiKey;
+}
+
+export async function detect(text) {
+  const key = await getKey();
+  if (!key) return null;
+  const res = await fetch("https://api.cognitive.microsofttranslator.com/detect?api-version=3.0", {
+    method: "POST",
+    headers: {
+      "Ocp-Apim-Subscription-Key": key,
+      "Content-type": "application/json"
+    },
+    body: JSON.stringify([{ Text: text }])
+  });
+  const data = await res.json();
+  return data[0]?.language;
+}
+
+export async function translateChunks(chunks, { from = 'auto', to }) {
+  const key = await getKey();
+  if (!key) throw new Error("Microsoft Translator API key missing");
+  const results = [];
+  for (const text of chunks) {
+    const url = new URL("https://api.cognitive.microsofttranslator.com/translate");
+    url.searchParams.set("api-version", "3.0");
+    url.searchParams.set("to", to);
+    if (from && from !== 'auto') {
+      url.searchParams.set("from", from);
+    }
+    const res = await fetch(url.toString(), {
+      method: "POST",
+      headers: {
+        "Ocp-Apim-Subscription-Key": key,
+        "Content-type": "application/json"
+      },
+      body: JSON.stringify([{ Text: text }])
+    });
+    const data = await res.json();
+    results.push(data[0].translations[0].text);
+  }
+  return results;
+}

--- a/thunderbird/background/index.js
+++ b/thunderbird/background/index.js
@@ -1,0 +1,20 @@
+import { getEngine } from "./engines/index.js";
+
+browser.runtime.onMessage.addListener(async (message, sender) => {
+  switch (message.type) {
+    case "translate": {
+      const { engine: engineName = "google", chunks, from = "auto", to } = message;
+      const engine = getEngine(engineName);
+      const translated = await engine.translateChunks(chunks, { from, to });
+      return { chunks: translated };
+    }
+    case "detect": {
+      const { engine: engineName = "google", text } = message;
+      const engine = getEngine(engineName);
+      const lang = await engine.detect(text);
+      return { lang };
+    }
+    default:
+      break;
+  }
+});

--- a/thunderbird/content/index.js
+++ b/thunderbird/content/index.js
@@ -1,0 +1,49 @@
+const EXCLUDE_SELECTOR = "blockquote[type='cite'], pre, code, kbd, samp";
+const originalTextMap = new Map();
+
+function collectTextNodes(root) {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      if (!node.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
+      const parent = node.parentElement;
+      if (parent && parent.closest(EXCLUDE_SELECTOR)) return NodeFilter.FILTER_REJECT;
+      return NodeFilter.FILTER_ACCEPT;
+    }
+  });
+  const nodes = [];
+  while (walker.nextNode()) {
+    nodes.push(walker.currentNode);
+  }
+  return nodes;
+}
+
+async function translateMessage({ engine, to }) {
+  if (originalTextMap.size) return; // already translated
+  const nodes = collectTextNodes(document.body);
+  const texts = nodes.map((n) => n.nodeValue);
+  const { chunks } = await browser.runtime.sendMessage({
+    type: "translate",
+    engine,
+    to,
+    chunks: texts
+  });
+  nodes.forEach((node, i) => {
+    originalTextMap.set(node, node.nodeValue);
+    node.nodeValue = chunks[i];
+  });
+}
+
+function restoreOriginal() {
+  for (const [node, text] of originalTextMap.entries()) {
+    node.nodeValue = text;
+  }
+  originalTextMap.clear();
+}
+
+browser.runtime.onMessage.addListener((message) => {
+  if (message.type === "translate") {
+    translateMessage(message);
+  } else if (message.type === "restore") {
+    restoreOriginal();
+  }
+});

--- a/thunderbird/content/styles.css
+++ b/thunderbird/content/styles.css
@@ -1,0 +1,1 @@
+/* Placeholder for overlay/replacement styles */

--- a/thunderbird/manifest.json
+++ b/thunderbird/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "TWP for Thunderbird – In-Place Email Translator",
+  "name": "TWP Thunderbird Translator",
   "version": "0.1.0",
   "description": "Translate entire email bodies in place using Google or Microsoft.",
   "browser_specific_settings": {
@@ -14,11 +14,7 @@
     "menus",
     "tabs",
     "messagesRead",
-    "messagesModify",
-    "*://translate.googleapis.com/*",
-    "*://translate.google.com/*",
-    "*://api.cognitive.microsofttranslator.com/*",
-    "*://www.bing.com/*"
+    "messagesModify"
   ],
   "background": {
     "scripts": ["background/index.js"]

--- a/thunderbird/manifest.json
+++ b/thunderbird/manifest.json
@@ -1,0 +1,39 @@
+{
+  "manifest_version": 2,
+  "name": "TWP for Thunderbird – In-Place Email Translator",
+  "version": "0.1.0",
+  "description": "Translate entire email bodies in place using Google or Microsoft.",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "twp-thunderbird@example.com",
+      "strict_min_version": "115.0"
+    }
+  },
+  "permissions": [
+    "storage",
+    "menus",
+    "tabs",
+    "messagesRead",
+    "messagesModify"
+  ],
+  "host_permissions": [
+    "*://translate.googleapis.com/*",
+    "*://translate.google.com/*",
+    "*://api.cognitive.microsofttranslator.com/*",
+    "*://www.bing.com/*"
+  ],
+  "background": {
+    "scripts": ["background/index.js"]
+  },
+  "message_display_action": {
+    "default_title": "Translate",
+    "default_popup": "ui/popup.html"
+  },
+  "message_display_scripts": [
+    {
+      "js": ["content/index.js"],
+      "css": ["content/styles.css"]
+    }
+  ],
+  "default_locale": "en"
+}

--- a/thunderbird/manifest.json
+++ b/thunderbird/manifest.json
@@ -14,9 +14,7 @@
     "menus",
     "tabs",
     "messagesRead",
-    "messagesModify"
-  ],
-  "host_permissions": [
+    "messagesModify",
     "*://translate.googleapis.com/*",
     "*://translate.google.com/*",
     "*://api.cognitive.microsofttranslator.com/*",

--- a/thunderbird/ui/popup.html
+++ b/thunderbird/ui/popup.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+</head>
+<body>
+  <label>
+    <span id="engine-label"></span>
+    <select id="engine">
+      <option value="google">Google</option>
+      <option value="microsoft">Microsoft</option>
+    </select>
+  </label>
+  <label>
+    <span id="lang-label"></span>
+    <select id="lang">
+      <option value="es">Spanish</option>
+      <option value="hy">Armenian</option>
+    </select>
+  </label>
+  <div>
+    <button id="translate"></button>
+    <button id="restore"></button>
+  </div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/thunderbird/ui/popup.js
+++ b/thunderbird/ui/popup.js
@@ -1,0 +1,20 @@
+function init() {
+  document.getElementById("engine-label").textContent = browser.i18n.getMessage("engine_label");
+  document.getElementById("lang-label").textContent = browser.i18n.getMessage("language_label");
+  document.getElementById("translate").textContent = browser.i18n.getMessage("translate_button");
+  document.getElementById("restore").textContent = browser.i18n.getMessage("restore_button");
+
+  document.getElementById("translate").addEventListener("click", async () => {
+    const engine = document.getElementById("engine").value;
+    const to = document.getElementById("lang").value;
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+    browser.tabs.sendMessage(tab.id, { type: "translate", engine, to });
+  });
+
+  document.getElementById("restore").addEventListener("click", async () => {
+    const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+    browser.tabs.sendMessage(tab.id, { type: "restore" });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
## Summary
- add Thunderbird MailExtension manifest with message-display hooks
- implement background router with pluggable Google and Microsoft engines
- add content script and popup UI for translating messages
- document build and installation steps
- remove unused icon assets from the extension manifest

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6316a3be48326b797ecc335ffb2a4